### PR TITLE
Adicionando classes de exceção

### DIFF
--- a/middleware/src/main/java/br/ufrn/dimap/middleware/remotting/impl/RemoteError.java
+++ b/middleware/src/main/java/br/ufrn/dimap/middleware/remotting/impl/RemoteError.java
@@ -1,0 +1,54 @@
+package br.ufrn.dimap.middleware.remotting.impl;
+
+/**
+ * This class represents an error that occurred
+ * at some point in the remote communication.
+ * It can be caused by several known factors during development time.
+ * 
+ * Note: Inheriting from Exception this class requires the programmer to handle the exception
+ * 
+ * @author MatheusAlvesA
+ */
+public class RemoteError extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	private String state;
+	
+	/*
+	 * Overwriting java exception constructors to grant all features.
+	 * */
+	public RemoteError() {/* empty */}
+	public RemoteError(String arg0) {super(arg0);}
+	public RemoteError(Throwable arg0) {super(arg0);}
+	public RemoteError(String arg0, Throwable arg1) {super(arg0, arg1);}
+	public RemoteError(String arg0, Throwable arg1, boolean arg2, boolean arg3) {super(arg0, arg1, arg2, arg3);}
+
+	/**
+	 * This function saves the state of a variable during the occurrence of the exception.
+	 * 
+	 * @param varName - Variable's name.
+	 * @param value - Value of the variable.
+	 */
+	public void addState(String varName, Object value) {
+		if(this.state == null)
+			this.state = "";
+
+		if(value != null)
+			this.state += "Var ("+value.getClass().getName()+") "+varName+" = "+value.toString()+"\n";
+		else
+			this.state += "Var (???) "+varName+" = NULL\n";
+	}
+	
+	/**
+	 * This function returns the state of the method variables at the time the exception occurred.
+	 * 
+	 * @return The state serialized of the method
+	 */
+	public String getState() {
+		if(this.state == null)
+			return "Nothing save on state\n";
+		return this.state;
+	}
+
+}

--- a/middleware/src/main/java/br/ufrn/dimap/middleware/remotting/impl/RuntimeRemoteError.java
+++ b/middleware/src/main/java/br/ufrn/dimap/middleware/remotting/impl/RuntimeRemoteError.java
@@ -1,0 +1,55 @@
+package br.ufrn.dimap.middleware.remotting.impl;
+
+/**
+ * This class represents an error that occurred
+ * at some point in the remote communication.
+ * It can be caused by several unknown factors during development time.
+ * 
+ * Note: Inheriting from RuntimeException this class do NOT requires
+ * the programmer to handle the exception
+ * 
+ * @author MatheusAlvesA
+ */
+public class RuntimeRemoteError extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private String state;
+	
+	/*
+	 * Overwriting java exception constructors to grant all features.
+	 * */
+	public RuntimeRemoteError() {/* empty */}
+	public RuntimeRemoteError(String arg0) {super(arg0);}
+	public RuntimeRemoteError(Throwable arg0) {super(arg0);}
+	public RuntimeRemoteError(String arg0, Throwable arg1) {super(arg0, arg1);}
+	public RuntimeRemoteError(String arg0, Throwable arg1, boolean arg2, boolean arg3) {super(arg0, arg1, arg2, arg3);}
+
+	/**
+	 * This function saves the state of a variable during the occurrence of the exception.
+	 * 
+	 * @param varName - Variable's name.
+	 * @param value - Value of the variable.
+	 */
+	public void addState(String varName, Object value) {
+		if(this.state == null)
+			this.state = "";
+
+		if(value != null)
+			this.state += "Var ("+value.getClass().getName()+") "+varName+" = "+value.toString()+"\n";
+		else
+			this.state += "Var (???) "+varName+" = NULL\n";
+	}
+	
+	/**
+	 * This function returns the state of the method variables at the time the exception occurred.
+	 * 
+	 * @return The state serialized of the method
+	 */
+	public String getState() {
+		if(this.state == null)
+			return "Nothing save on state\n";
+		return this.state;
+	}
+
+}


### PR DESCRIPTION
## Adicionei duas classes para representar as exceções remotas.

**RemoteException** é uma classe que herda diretamente de Exception, ou seja: é uma exceção checada. Deve ser usada para representar erros previsíveis(Ex: Falha na conexão).

**RuntimeRemoteError** é uma classe que herda de RuntimeException, ou seja: não é checada podendo não ser tratada. deve ser usada em situações onde um erro que não deveria ocorrer acontece(Um método recebe null como valor de uma parâmetro de entrada que não podia ser nulo).

Existe também a função addState(nome, valor) que guarda internamente na exceção, o nome e valor de uma variável do método onde a exceção ocorreu, podendo ser usando para armazenar todas as variáveis do método a fim de debugar posteriormente.
getState() por sua vez retorna todas as variáveis e seus valores salvos por addState() em uma string legível a humanos.

Ex:

`e.addState("nome" "paulo")`
`e.getState()`
`// Saída: "Var (lava.lang.String) nome = paulo"`

---

`addState()` e `getState()` são de uso totalmente opcional, coloquei só pq imagino que possa ser útil a alguém. 