### PR TITLE
Passa a ignorar os arquivos de IDE do IntelliJ no versionamento.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,10 +141,11 @@ fabric.properties
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+.idea
 
 # Sonarlint plugin
 .idea/sonarlint


### PR DESCRIPTION
Como o projeto é compartilhado por muitas pessoas usando IDEs diferentes, é interessante que nenhuma informação sobre as IDEs sejam versionadas.
Visto isso, toda a pasta .idea e o arquivo de projeto *.iml deve ser ignorado.

Obs: a leitura do comentários no gitignore explicita que só há vantagem versionar quando todos usam IntelliJ e não precisaria reconfigurar os módulos.