### PR TITLE
Improve id package

### DIFF
--- a/middleware/src/main/java/br/ufrn/dimap/middleware/identification/AbsoluteObjectReference.java
+++ b/middleware/src/main/java/br/ufrn/dimap/middleware/identification/AbsoluteObjectReference.java
@@ -13,21 +13,17 @@ public class AbsoluteObjectReference {
 	private ObjectId objectId;
 	private String host;
 	private int port;
-	private int invokerId;
 	
 	/**
 	 * Creates the unique identifier for remote objects: AOR
 	 * @param objectId	The remote object's object id
 	 * @param host		Host of the network
 	 * @param port		Port of the network
-	 * @param invokerId	Invoker unique identification
 	 */
-	public AbsoluteObjectReference(ObjectId objectId, String host, int port,
-								   int invokerId) {
+	public AbsoluteObjectReference(ObjectId objectId, String host, int port) {
 		this.objectId = objectId;
 		this.host = host;
 		this.port = port;
-		this.invokerId = invokerId;
 	}
 	
 	/**
@@ -53,13 +49,4 @@ public class AbsoluteObjectReference {
 	public int getPort() {
 		return port;
 	}
-	
-	/**
-	 * 
-	 * @return	AOR invoker identification
-	 */
-	public int getInvokerId() {
-		return invokerId;
-	}
-	
 }

--- a/middleware/src/main/java/br/ufrn/dimap/middleware/identification/lookup/Lookup.java
+++ b/middleware/src/main/java/br/ufrn/dimap/middleware/identification/lookup/Lookup.java
@@ -1,6 +1,7 @@
 package br.ufrn.dimap.middleware.identification.lookup;
 
 import br.ufrn.dimap.middleware.identification.AbsoluteObjectReference;
+import br.ufrn.dimap.middleware.identification.ObjectId;
 import br.ufrn.dimap.middleware.remotting.impl.RemoteError;
 
 /**
@@ -22,8 +23,9 @@ public interface Lookup {
 	 * 				reference.
 	 * @param aor	The absolute object reference that must be binded with the 
 	 * 				given name (propertied).
+	 * @throws RemoteError
 	 */
-	public void bind(String name, AbsoluteObjectReference aor) throws RemoteError;
+	public void bind(String name, Object remoteObject) throws RemoteError;
 	
 	/**
 	 * Allow clients to use lookup service to query for the ABSOLUTE OBJECT 
@@ -32,6 +34,17 @@ public interface Lookup {
 	 * @param name	Name that'll be used to find the absolute object reference, 
 	 * 				previously binded with this same name.
 	 * @return		The absolute object reference binded with the given name.
+	 * @throws RemoteError
 	 */
-	public AbsoluteObjectReference find(String name) throws RemoteError;;
+	public AbsoluteObjectReference find(String name) throws RemoteError;
+	
+	/**
+	 * Allow the server requestor find the remote object reference given an 
+	 * object id.
+	 * 
+	 * @param objectId Unique identifier of remote object.
+	 * @return Correspondent of this object id.
+	 * @throws RemoteError
+	 */
+	public Object findById(ObjectId objectId) throws RemoteError;
 }

--- a/middleware/src/main/java/br/ufrn/dimap/middleware/identification/lookup/Lookup.java
+++ b/middleware/src/main/java/br/ufrn/dimap/middleware/identification/lookup/Lookup.java
@@ -23,9 +23,12 @@ public interface Lookup {
 	 * 				reference.
 	 * @param aor	The absolute object reference that must be binded with the 
 	 * 				given name (propertied).
+	 * @param host Server connection host.
+	 * @param port Server connection port.
 	 * @throws RemoteError
 	 */
-	public void bind(String name, Object remoteObject) throws RemoteError;
+	public void bind(String name, Object remoteObject, String host, int port) 
+			throws RemoteError;
 	
 	/**
 	 * Allow clients to use lookup service to query for the ABSOLUTE OBJECT 


### PR DESCRIPTION
As discussed in the classroom last Tuesday, I had to make some changes to the Lookup interface signature and to the AOR class.

At first, we'll need the lookup to also get the host and port from the server - and then we'll think of some workaround to get this automatically.

We also created a new method that (probably) will be used by the server requestor to retrieve the remote object given an identifier.